### PR TITLE
Added support for filtering out tweets

### DIFF
--- a/spec/tweetbot_config_spec.rb
+++ b/spec/tweetbot_config_spec.rb
@@ -93,6 +93,20 @@ describe "configuring tweetbot with a config block" do
     end
   end
 
+  context "configuring filters" do
+    let(:bot) do
+      TweetBot.configure do |bot|
+        bot.filter_out "\@\S" do |filter_reasons|
+          filter_reasons << "filtering out conversations"
+        end
+      end
+    end
+
+    it "has filters for a conversational tweet" do
+      bot.filters_for("\@\S").should =~ ["filtering out conversations"]
+    end
+  end
+
   context "configuring a status captured block" do
     let(:statuses) { [] }
     let(:bot) do


### PR DESCRIPTION
Added in the ability to provide filters to be evaluated as part of the "should_i_respond?" process.

I followed the pattern set for looking for responses the tweet.  Essentially each tweet will be evaluated against a collection of filters.  if a tweet matches a filter the bot will not respond.  This allows for a more robust / finer grained management of which tweets get replied to.

In addition to the filters themselves I have enabled the configuration to be able to provide a regular expression as a phrase or filter.

for example for the happiness bot where it is looking for the phrase "Good Morning": In order to not but in on conversations we may want filter out tweets that are targeted to another user.  For example: "@coreyhains Good Morning!".    To accomplish this you would call filter_out /\@\S+/  (filter out messages with an @ symbol followed by 1 or many non space characters)

You can provide the reason for the filter, however currently this is for reference only and is not currently logged.

enjoy!
--Paul
